### PR TITLE
docs: add GitHub Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ Replace `<your-token>` with your personal API token generated at https://guide.s
 }
 ```
 
+### GitHub Copilot CLI
+
+Add to your `~/.copilot/mcp-config.json`:
+
+Replace `<your-token>` with your personal API token generated at https://guide.sonatype.com/settings/tokens
+
+```json
+{
+  "mcpServers": {
+    "sonatype-mcp": {
+      "type": "http",
+      "url": "https://mcp.guide.sonatype.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
 ### Windsurf
 
 Create or edit `~/.codeium/windsurf/mcp_config.json`:


### PR DESCRIPTION
Adds a "GitHub Copilot CLI" section to the Setup instructions, alongside the other supported clients.

## Changes
- Added GitHub Copilot CLI section with `~/.copilot/mcp-config.json` configuration
- Used HTTP config format matching Cursor (since both support remote servers natively)
- Followed existing pattern for token instructions

This helps GitHub Copilot CLI users discover how to configure the Sonatype MCP Server.